### PR TITLE
Feature/reservedcodecachesize

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,7 +45,7 @@ confluence_catalina: "/opt/atlassian/confluence"
 # JVM minimal and maximum memory usage.
 confluence_jvm_minimum_memory: "1024m"
 confluence_jvm_maximum_memory: "1024m"
-confluence_jvm_Reserved_code_cache_size: "256m"
+confluence_jvm_reserved_code_cache_size: "256m"
 
 # Proxy and context path setup.
 confluence_catalina_connector_proxyname: ~

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,6 +45,7 @@ confluence_catalina: "/opt/atlassian/confluence"
 # JVM minimal and maximum memory usage.
 confluence_jvm_minimum_memory: "1024m"
 confluence_jvm_maximum_memory: "1024m"
+confluence_jvm_Reserved_code_cache_size: "256m"
 
 # Proxy and context path setup.
 confluence_catalina_connector_proxyname: ~

--- a/templates/opt/atlassian/confluence/bin/setenv.sh.j2
+++ b/templates/opt/atlassian/confluence/bin/setenv.sh.j2
@@ -82,7 +82,7 @@ CATALINA_OPTS="-Dcatalina.connector.proxyPort=${CATALINA_CONNECTOR_PROXYPORT:-"{
 CATALINA_OPTS="-Dcatalina.connector.scheme=${CATALINA_CONNECTOR_SCHEME:-"{{ confluence_catalina_connector_scheme }}"} ${CATALINA_OPTS}"
 CATALINA_OPTS="-Dcatalina.connector.secure=${CATALINA_CONNECTOR_SECURE:-"{{ confluence_catalina_connector_secure }}"} ${CATALINA_OPTS}"
 CATALINA_OPTS="-Dcatalina.context.path=${CATALINA_CONTEXT_PATH:-"{{ confluence_catalina_context_path }}"} ${CATALINA_OPTS}"
-CATALINA_OPTS="-XX:ReservedCodeCacheSize=256m -XX:+UseCodeCacheFlushing ${CATALINA_OPTS}"
+CATALINA_OPTS="-XX:ReservedCodeCacheSize={{ confluence_jvm_Reserved_code_cache_size }} -XX:+UseCodeCacheFlushing ${CATALINA_OPTS}"
 
 
 export CATALINA_OPTS

--- a/templates/opt/atlassian/confluence/bin/setenv.sh.j2
+++ b/templates/opt/atlassian/confluence/bin/setenv.sh.j2
@@ -82,7 +82,7 @@ CATALINA_OPTS="-Dcatalina.connector.proxyPort=${CATALINA_CONNECTOR_PROXYPORT:-"{
 CATALINA_OPTS="-Dcatalina.connector.scheme=${CATALINA_CONNECTOR_SCHEME:-"{{ confluence_catalina_connector_scheme }}"} ${CATALINA_OPTS}"
 CATALINA_OPTS="-Dcatalina.connector.secure=${CATALINA_CONNECTOR_SECURE:-"{{ confluence_catalina_connector_secure }}"} ${CATALINA_OPTS}"
 CATALINA_OPTS="-Dcatalina.context.path=${CATALINA_CONTEXT_PATH:-"{{ confluence_catalina_context_path }}"} ${CATALINA_OPTS}"
-CATALINA_OPTS="-XX:ReservedCodeCacheSize={{ confluence_jvm_Reserved_code_cache_size }} -XX:+UseCodeCacheFlushing ${CATALINA_OPTS}"
+CATALINA_OPTS="-XX:ReservedCodeCacheSize={{ confluence_jvm_reserved_code_cache_size }} -XX:+UseCodeCacheFlushing ${CATALINA_OPTS}"
 
 
 export CATALINA_OPTS


### PR DESCRIPTION
On one of my servers in the admin under "Troubleshooting and support tools" /plugins/servlet/troubleshooting/view/ there was a warning being thrown about the "Java Virtual Machine -> Code Cache Memory" and it was indicating that the size of it needed to be bigger. Documentation about the warning pointed to an Atlassian document https://confluence.atlassian.com/confkb/health-check-jvm-code-cache-979409394.html about configuring the ReservedCodeCacheSize in setenv.sh so I have adjusted the ansible template here to make the value for that option a variable that can be adjusted.

In the template file the value was set to 256m though in the Atlassian documentation it claims to use a default of 384m, and when I changed my server to 384m the warning went away. I'm not sure if this is any indication that the default in the role should be updated to 256m or if you had a specific reason for it being that size, but utilizing a variable makes this work either way now.