### PR TITLE
Introduce default var confluence_download_directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   - Migrate role name to lowercase or underline
   - Migrate group name to lowercase or underline
   - Migrate molecule `group_vars` to file
-  - Download archives to `{{ ansible_user_dir }}/.ansible/tmp`
+  - Download archives to `{{ confluence_download_directory }}`
   - Remove System V init scripts
 
 ## 4.2.0 - 2020-02-13

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,9 @@
 # Confluence version.
 confluence_version: "7.3.4"
 
+# Confluence download directory.
+confluence_download_directory: "{{ ansible_user_dir }}/.ansible/tmp"
+
 # Confluence download details.
 confluence_download: "{{ _confluence_download[confluence_version] }}"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -17,41 +17,41 @@
 _confluence_download:
   7.3.4:
     url: "https://product-downloads.atlassian.com/software/confluence/downloads/atlassian-confluence-7.3.4.tar.gz"
-    dest: "{{ ansible_user_dir }}/.ansible/tmp/atlassian-confluence-7.3.4.tar.gz"
+    dest: "{{ confluence_download_directory }}/atlassian-confluence-7.3.4.tar.gz"
     checksum: "sha1:fdb928fffa7adad94b3032a83eb741a3daae0422"
   7.3.3:
     url: "https://product-downloads.atlassian.com/software/confluence/downloads/atlassian-confluence-7.3.3.tar.gz"
-    dest: "{{ ansible_user_dir }}/.ansible/tmp/atlassian-confluence-7.3.3.tar.gz"
+    dest: "{{ confluence_download_directory }}/atlassian-confluence-7.3.3.tar.gz"
     checksum: "sha1:5ee3f2b3b409fe4b50d6c0fb64c5274cae04a418"
   7.3.2:
     url: "https://product-downloads.atlassian.com/software/confluence/downloads/atlassian-confluence-7.3.2.tar.gz"
-    dest: "{{ ansible_user_dir }}/.ansible/tmp/atlassian-confluence-7.3.2.tar.gz"
+    dest: "{{ confluence_download_directory }}/atlassian-confluence-7.3.2.tar.gz"
     checksum: "sha1:f0f7a862474509e8cdd716e60ff2c3653d78f872"
   7.3.1:
     url: "https://product-downloads.atlassian.com/software/confluence/downloads/atlassian-confluence-7.3.1.tar.gz"
-    dest: "{{ ansible_user_dir }}/.ansible/tmp/atlassian-confluence-7.3.1.tar.gz"
+    dest: "{{ confluence_download_directory }}/atlassian-confluence-7.3.1.tar.gz"
     checksum: "sha1:88caceb90a6c32b3f1d8986cb3091d6af4cdceab"
   7.2.2:
     url: "https://product-downloads.atlassian.com/software/confluence/downloads/atlassian-confluence-7.2.2.tar.gz"
-    dest: "{{ ansible_user_dir }}/.ansible/tmp/atlassian-confluence-7.2.2.tar.gz"
+    dest: "{{ confluence_download_directory }}/atlassian-confluence-7.2.2.tar.gz"
     checksum: "sha1:c67f3abb10ec2977542a30771221f5b068475aed"
   7.2.1:
     url: "https://product-downloads.atlassian.com/software/confluence/downloads/atlassian-confluence-7.2.1.tar.gz"
-    dest: "{{ ansible_user_dir }}/.ansible/tmp/atlassian-confluence-7.2.1.tar.gz"
+    dest: "{{ confluence_download_directory }}/atlassian-confluence-7.2.1.tar.gz"
     checksum: "sha1:7f9a1685a71ea8edc2982943a05717636df44b8d"
   7.2.0:
     url: "https://product-downloads.atlassian.com/software/confluence/downloads/atlassian-confluence-7.2.0.tar.gz"
-    dest: "{{ ansible_user_dir }}/.ansible/tmp/atlassian-confluence-7.2.0.tar.gz"
+    dest: "{{ confluence_download_directory }}/atlassian-confluence-7.2.0.tar.gz"
     checksum: "sha1:be9f5123374cb7d89932b03338f05c2d520a73ed"
 
 _mysql_jdbc_download:
   5.1.48:
     url: "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.48.tar.gz"
-    dest: "{{ ansible_user_dir }}/.ansible/tmp/mysql-connector-java-5.1.48.tar.gz"
+    dest: "{{ confluence_download_directory }}/mysql-connector-java-5.1.48.tar.gz"
     checksum: "sha1:a8067480d7d7e4a975771e08b48b64de18837341"
 
 _postgresql_jdbc_download:
   42.2.12:
     url: "https://jdbc.postgresql.org/download/postgresql-42.2.12.jar"
-    dest: "{{ ansible_user_dir }}/.ansible/tmp/postgresql-42.2.12.jar"
+    dest: "{{ confluence_download_directory }}/postgresql-42.2.12.jar"
     checksum: "sha1:1ed5b5f16a67f312a50d420e8bcb7d30b40b033d"


### PR DESCRIPTION
**Changes:**

Introduce default var `confluence_download_directory` to support overriding the download path at role usage level.