### PR TITLE
Bump Confluence version 7.19 from 7.19.1 to 7.19.2

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -15,6 +15,6 @@
 # limitations under the License.
 
 _confluence_version:
-  "7.19": "7.19.1"
+  "7.19": "7.19.2"
   "7.18": "7.18.3"
   "7.13": "7.13.9"


### PR DESCRIPTION
This is to resolve Confluence not updating due to package version being bumped in OBS.